### PR TITLE
Gracefully handle case where no caches are found

### DIFF
--- a/handle_http.go
+++ b/handle_http.go
@@ -222,7 +222,12 @@ func download_http(source string, destination string, payload *payloadStruct, na
 		log.Debugln("Cache:", cache)
 		transfers = append(transfers, NewTransferDetails(cache, namespace.ReadHTTPS || namespace.UseTokenOnRead)...)
 	}
-	log.Debugln("Transfers:", transfers[0].Url.Opaque)
+	if len(transfers) > 0 {
+		log.Debugln("Transfers:", transfers[0].Url.Opaque)
+	} else {
+		log.Debugln("No transfers possible as no caches are found")
+		return 0, errors.New("No transfers possible as no caches are found")
+	}
 	// Create the wait group and the transfer files
 	var wg sync.WaitGroup
 


### PR DESCRIPTION
Instead of panic'ing when no caches are found (as the debug statement prints the first cache), gracefully exit and return an error.