### PR TITLE
Fix classad parsing when special characters in string

### DIFF
--- a/classads/classads.go
+++ b/classads/classads.go
@@ -166,7 +166,7 @@ func attributeSplitFunc(data []byte, atEOF bool) (advance int, token []byte, err
 	// Watch out for semi-colons inside quotes
 	insideQuotes := false
 	for i, curChar := range data {
-		if curChar == '"' && data[i-1] != '\\' {
+		if curChar == '"' && !(i > 0 && data[i-1] == '\\') {
 			insideQuotes = !insideQuotes
 		} else if curChar == ';' && !insideQuotes {
 			// Do not return the semi-colon


### PR DESCRIPTION
When a [, ], or ; are in a string value, do not treat them as special separators.

Fixes htcondor/osdf-client#32