### PR TITLE
Allow HTTP 206 Partial Content responses

### DIFF
--- a/handle_http.go
+++ b/handle_http.go
@@ -514,7 +514,9 @@ Loop:
 		log.Debugln("Got error from HTTP download", err)
 		return 0, err
 	}
-	if resp.HTTPResponse.StatusCode != 200 {
+        // Valid responses include 200 and 206.  The latter occurs if the download was resumed after a
+        // prior attempt.
+	if resp.HTTPResponse.StatusCode != 200 && resp.HTTPResponse.StatusCode != 206 {
 		log.Debugln("Got failure status code:", resp.HTTPResponse.StatusCode)
 		return 0, errors.New("failure status code")
 	}


### PR DESCRIPTION
If the underlying grab library resumes a partially-downloaded file, then the correct HTTP response is "206 Partial Content", not 200. Change the HTTP handler to allow 206 as a successful response.

To test:
1.  Apply the branch at https://github.com/xrootd/xrootd/pull/1920 to XCache to make responses work correctly.
2. Apply the following patch to your build to make XCache fail every-other-time:
```
--- a/src/XrdPss/XrdPss.cc
+++ b/src/XrdPss/XrdPss.cc
@@ -1018,12 +1018,15 @@ ssize_t XrdPssFile::Read(off_t offset, size_t blen)
   Output:   Returns the number bytes read upon success and -errno upon failure.
 */
 
+static int fail_ctr = 0;
 ssize_t XrdPssFile::Read(void *buff, off_t offset, size_t blen)
 {
      ssize_t retval;
 
      if (fd < 0) return (ssize_t)-XRDOSS_E8004;
 
+     if (fail_ctr % 2 == 0 && offset == 42991616) {fail_ctr++; return -EIO;}
+
      return (retval = XrdPosixXrootd::Pread(fd, buff, blen, offset)) < 0
             ? (ssize_t)-errno : retval;
 }
```

(This means it'll fail the first download attempt at 42MB but then succeed at  the second)

Fixes: #43 