### PR TITLE
Do not attempt methods doomed to fail

### DIFF
--- a/cmd/stashcp/main.go
+++ b/cmd/stashcp/main.go
@@ -39,8 +39,8 @@ type Options struct {
 	// A JSON file containing the list of caches
 	CacheJSON string `short:"j" long:"caches-json" description:"A JSON file containing the list of caches"`
 
-	// Comma separated list of methods to try, in order.  Default: cvmfs,xrootd,http
-	Methods string `long:"methods" description:"Comma separated list of methods to try, in order." default:"cvmfs,xrootd,http"`
+	// Comma separated list of methods to try, in order.  Default: cvmfs,http
+	Methods string `long:"methods" description:"Comma separated list of methods to try, in order." default:"cvmfs,http"`
 
 	// Token file to use for reading and/or writing
 	Token string `long:"token" short:"t" description:"Token file to use for reading and/or writing"`

--- a/main.go
+++ b/main.go
@@ -378,11 +378,15 @@ Loop:
 
 		switch method {
 		case "cvmfs":
-			log.Info("Trying CVMFS...")
-			if downloaded, err = download_cvmfs(sourceFile, destination, &payload); err == nil {
-				success = true
-				break Loop
-				//check if break still works
+			if strings.HasPrefix(sourceFile, "/osgconnect/") {
+				log.Info("Trying CVMFS...")
+				if downloaded, err = download_cvmfs(sourceFile, destination, &payload); err == nil {
+					success = true
+					break Loop
+					//check if break still works
+				}
+			} else {
+				log.Debug("Skipping CVMFS as file does not start with /osgconnect/")
 			}
 		case "http":
 			log.Info("Trying HTTP...")


### PR DESCRIPTION
- CVMFS should only be tried for /osgconnect/ prefixes as that's the only paths published and supported.
- Remove `xrootd` from the list of methods as that's no longer supported.