### PR TITLE
Cleanup error messages

### DIFF
--- a/cmd/stash_plugin/main.go
+++ b/cmd/stash_plugin/main.go
@@ -179,7 +179,15 @@ func main() {
 			if stashcp.GetErrors() == "" {
 				resultAd.Set("TransferError", result.Error())
 			} else {
-				resultAd.Set("TransferError", stashcp.GetErrors())
+				errMsg := " Failure "
+				if upload {
+					errMsg += "uploading "
+				} else {
+					errMsg += "downloading "
+				}
+				errMsg += transfer.url + ": " + stashcp.GetErrors()
+				resultAd.Set("TransferError", errMsg)
+				stashcp.ClearErrors()
 			}
 			resultAd.Set("TransferFileBytes", 0)
 			resultAd.Set("TransferTotalBytes", 0)

--- a/cmd/stashcp/main.go
+++ b/cmd/stashcp/main.go
@@ -225,19 +225,23 @@ func main() {
 
 	var result error
 	var downloaded int64 = 0
+	lastSrc := ""
 	for _, src := range source {
 		var tmpDownloaded int64
 		tmpDownloaded, result = stashcp.DoStashCPSingle(src, dest, splitMethods, options.Recursive)
 		downloaded += tmpDownloaded
 		if result != nil {
+			lastSrc = src
 			break
+		} else {
+			stashcp.ClearErrors()
 		}
 	}
 
 	// Exit with failure
 	if result != nil {
 		// Print the list of errors
-		log.Errorln(stashcp.GetErrors())
+		log.Errorln("Failure downloading " + lastSrc + ": " + stashcp.GetErrors())
 		if stashcp.ErrorsRetryable() {
 			log.Errorln("Errors are retryable")
 			os.Exit(11)

--- a/errorAccum.go
+++ b/errorAccum.go
@@ -3,27 +3,59 @@ package stashcp
 import (
 	"errors"
 	"sync"
+	"time"
 )
 
+type TimestampedError struct {
+	err error
+	timestamp time.Time
+}
+
 var (
-	bunchOfErrors []error
+	bunchOfErrors []TimestampedError
 	mu            sync.Mutex
+	// We will generate an error string including the time since startup
+	startup       time.Time = time.Now()
 )
 
 // AddError will add an accumulated error to the error stack
 func AddError(err error) bool {
 	mu.Lock()
 	defer mu.Unlock()
-	bunchOfErrors = append(bunchOfErrors, err)
+	bunchOfErrors = append(bunchOfErrors, TimestampedError{err, time.Now()})
 	return true
 }
 
 func GetErrors() string {
 	mu.Lock()
 	defer mu.Unlock()
-	var toReturn string
+	first := true
+	lastError := startup
+	var errorsFormatted []string
 	for _, theError := range bunchOfErrors {
-		toReturn += theError.Error() + ";"
+		errFmt := theError.err.Error()
+		timeElapsed := theError.timestamp.Sub(lastError)
+		timeFormat := timeElapsed.Truncate(100*time.Millisecond).String()
+		errFmt += " (" + timeFormat
+		if first {
+			errFmt += " since start)"
+		} else {
+			timeSinceStart := theError.timestamp.Sub(startup)
+			timeSinceStartFormat := timeSinceStart.Truncate(100*time.Millisecond).String()
+			errFmt += " elapsed, " + timeSinceStartFormat + " since start)"
+		}
+		lastError = theError.timestamp
+		errorsFormatted = append(errorsFormatted, errFmt)
+		first = false
+	}
+	var toReturn string
+	first = true
+	for idx := len(errorsFormatted)-1; idx >= 0; idx-- {
+		if !first {
+			toReturn += "; "
+		}
+		toReturn += errorsFormatted[idx]
+		first = false
 	}
 	return toReturn
 }
@@ -43,7 +75,7 @@ func ErrorsRetryable() bool {
 	defer mu.Unlock()
 	// Loop through the errors and see if all of them are retryable
 	for _, theError := range bunchOfErrors {
-		if !IsRetryable(theError) {
+		if !IsRetryable(theError.err) {
 			return false
 		}
 	}

--- a/errorAccum.go
+++ b/errorAccum.go
@@ -30,6 +30,13 @@ func AddError(err error) bool {
 	return true
 }
 
+func ClearErrors() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	bunchOfErrors = make([]TimestampedError, 0)
+}
+
 func GetErrors() string {
 	mu.Lock()
 	defer mu.Unlock()

--- a/errorAccum_test.go
+++ b/errorAccum_test.go
@@ -10,9 +10,9 @@ import (
 
 //  TestErrorAccum tests simple adding and removing from the accumulator
 func TestErrorAccum(t *testing.T) {
-	bunchOfErrors = make([]error, 0)
+	bunchOfErrors = make([]TimestampedError, 0)
 	defer func() {
-		bunchOfErrors = make([]error, 0)
+		bunchOfErrors = make([]TimestampedError, 0)
 	}()
 	// Case 1: cache with http
 	err := errors.New("error1")
@@ -27,9 +27,9 @@ func TestErrorAccum(t *testing.T) {
 
 // TestErrorsRetryableFalse tests that errors are not retryable
 func TestErrorsRetryableFalse(t *testing.T) {
-	bunchOfErrors = make([]error, 0)
+	bunchOfErrors = make([]TimestampedError, 0)
 	defer func() {
-		bunchOfErrors = make([]error, 0)
+		bunchOfErrors = make([]TimestampedError, 0)
 	}()
 	// Case 2: cache with http
 	AddError(&SlowTransferError{})
@@ -47,9 +47,9 @@ func TestErrorsRetryableFalse(t *testing.T) {
 
 // TestErrorsRetryableTrue tests that errors are retryable
 func TestErrorsRetryableTrue(t *testing.T) {
-	bunchOfErrors = make([]error, 0)
+	bunchOfErrors = make([]TimestampedError, 0)
 	defer func() {
-		bunchOfErrors = make([]error, 0)
+		bunchOfErrors = make([]TimestampedError, 0)
 	}()
 	// Try with a retryable error nested error
 	AddError(&url.Error{Err: &SlowTransferError{}})

--- a/errorAccum_test.go
+++ b/errorAccum_test.go
@@ -21,7 +21,7 @@ func TestErrorAccum(t *testing.T) {
 	AddError(err2)
 
 	errStr := GetErrors()
-	assert.Equal(t, "error1;error2;", errStr)
+	assert.Equal(t, "Attempt #2: error2 (0s elapsed, 0s since start); Attempt #1: error1 (0s since start)", errStr)
 
 }
 

--- a/handle_http.go
+++ b/handle_http.go
@@ -80,7 +80,11 @@ type ConnectionSetupError struct {
 
 func (e *ConnectionSetupError) Error() string {
 	if e.Err != nil {
-		return "failed setup connection to " + e.URL + ": " + e.Err.Error()
+		if len(e.URL) > 0 {
+			return "failed connection setup to " + e.URL + ": " + e.Err.Error()
+		} else {
+			return "failed connection setup: " + e.Err.Error()
+		}
 	} else {
 		return "Connection to remote server failed"
 	}
@@ -305,7 +309,8 @@ func startDownloadWorker(source string, destination string, token string, transf
 			log.Debugln("Constructed URL:", transfer.Url.String())
 			if downloaded, err = DownloadHTTP(transfer, finalDest, token); err != nil {
 				log.Debugln("Failed to download:", err)
-				toAccum := errors.New("Failed to download from " + transfer.Url.String() +
+				toAccum := errors.New("Failed to download from " + transfer.Url.Hostname() + ":" +
+					transfer.Url.Port() +
 					" + proxy=" + strconv.FormatBool(transfer.Proxy) +
 					": " + err.Error())
 				AddError(toAccum)

--- a/handle_http.go
+++ b/handle_http.go
@@ -54,6 +54,9 @@ func (e *SlowTransferError) Is(target error) bool {
 
 // Determines whether or not we can interact with the site HTTP proxy
 func IsProxyEnabled() bool {
+	if _, isSet := os.LookupEnv("http_proxy"); !isSet {
+		return false
+	}
 	for _, prefix := range env_prefixes {
 		if _, isSet := os.LookupEnv(prefix + "_DISABLE_HTTP_PROXY"); isSet {
 			return false

--- a/handle_http_test.go
+++ b/handle_http_test.go
@@ -34,6 +34,8 @@ func TestIsPort(t *testing.T) {
 
 // TestNewTransferDetails checks the creation of transfer details
 func TestNewTransferDetails(t *testing.T) {
+	os.Setenv("http_proxy", "http://proxy.edu:3128")
+
 	// Case 1: cache with http
 	testCache := Cache{
 		AuthEndpoint: "cache.edu:8443",


### PR DESCRIPTION
- Ensure we always print time elapsed and since start
- Reverse order so newest message is listed first (readability)
- Small formatting tweaks for readability.

Example of new format (linebreaks added):

```
Failed to download from stash-cache.osg.chtc.io:8443 + proxy=false: failed connection setup: server returned 403 Forbidden (1.1s elapsed, 2.4s since start);
Failed to download from stash-cache.osg.chtc.io:8443 + proxy=true: failed connection setup: Head "http://stash-cache.osg.chtc.io:8443/osgconnect/public/bbockelm/namespaces.json": proxyconnect tcp: dial tcp [2600:900:6:1101:e63d:1aff:fe07:4ac0]:3129: connect: connection refused (1.2s since start)
```

If `http_proxy` is unset then don't bother one attempt with the proxy enabled and one with the proxy disabled.  Just try once and reduce the noise in the error message.

Fixes #45 
Fixes #42 