### PR TITLE
Handle issuers with non-standard paths

### DIFF
--- a/namespaces.go
+++ b/namespaces.go
@@ -38,6 +38,7 @@ type Namespace struct {
 	Caches         []Cache `json:"caches"`
 	Path           string  `json:"path"`
 	Issuer         string  `json:"issuer"`
+	IssuerBasePath string  `json:"issuer_base_path"`
 	ReadHTTPS      bool    `json:"readhttps"`
 	UseTokenOnRead bool    `json:"usetokenonread"`
 	WriteBackHost  string  `json:"writebackhost"`


### PR DESCRIPTION
An issuer _should_ use the same base path as the corresponding path in the namespace.  This is not always true, however.  The CHTC issuer, for example, uses the base path of /chtc for the namespace /chtc/PROTECTED.

The detection logic must know this in order to determine if a given token is applicable.