### PR TITLE
Update the issuer selection code to match topology

### DIFF
--- a/acquire_token.go
+++ b/acquire_token.go
@@ -118,9 +118,13 @@ func AcquireToken(destination *url.URL, namespace Namespace, isWrite bool) (stri
 	if namespace.CredentialGen == nil || namespace.CredentialGen.Strategy == nil {
 		return "", fmt.Errorf("Credential generation scheme unknown for prefix %s", namespace.Path)
 	}
-	if *namespace.CredentialGen.Strategy != "OAuth2" {
+	switch strategy := *namespace.CredentialGen.Strategy; strategy {
+	case "OAuth2":
+	case "Vault":
+		return "", fmt.Errorf("Vault credential generation strategy is not supported")
+	default:
 		return "", fmt.Errorf("Unknown credential generation strategy (%s) for prefix %s",
-                                      *namespace.CredentialGen.Strategy, namespace.Path)
+                                      strategy, namespace.Path)
 	}
 	issuer := *namespace.CredentialGen.Issuer
 	if len(issuer) == 0 {

--- a/namespaces.go
+++ b/namespaces.go
@@ -33,15 +33,23 @@ type Cache struct {
 	Resource     string `json:"resource"`
 }
 
+// Credential generation information
+type CredentialGeneration struct {
+	Issuer        *string  `json:"issuer"`
+	MaxScopeDepth *int     `json:"max_scope_depth"`
+	Strategy      *string `json:"strategy"`
+	VaultServer   *string `json:"vault_server"`
+}
+
 // Namespace holds the structure of stash namespaces
 type Namespace struct {
-	Caches         []Cache `json:"caches"`
-	Path           string  `json:"path"`
-	Issuer         string  `json:"issuer"`
-	ReadHTTPS      bool    `json:"readhttps"`
-	UseTokenOnRead bool    `json:"usetokenonread"`
-	WriteBackHost  string  `json:"writebackhost"`
-	DirListHost    string  `json:"dirlisthost"`
+	Caches         []Cache               `json:"caches"`
+	Path           string                `json:"path"`
+	CredentialGen *CredentialGeneration  `json:"credential_generation"`
+	ReadHTTPS      bool                  `json:"readhttps"`
+	UseTokenOnRead bool                  `json:"usetokenonread"`
+	WriteBackHost  string                `json:"writebackhost"`
+	DirListHost    string                `json:"dirlisthost"`
 }
 
 // GetCaches returns the list of caches for the namespace


### PR DESCRIPTION
Between the initial draft of the JSON schema for `stashcp` and the final one in topology, there was some drift.  This updates the `stashcp` side to match the current contents of https://topology.opensciencegrid.org/osdf/namespaces