### PR TITLE
Improve TestSlowTransfer, add StoppedTransfer error, and TestStoppedTransfer

### DIFF
--- a/handle_http_test.go
+++ b/handle_http_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 	"time"
-
+	
 	"github.com/stretchr/testify/assert"
 )
 
@@ -102,12 +102,24 @@ func TestNewTransferDetailsEnv(t *testing.T) {
 }
 
 func TestSlowTransfers(t *testing.T) {
-
 	channel := make(chan bool)
-	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Don't send any response
-		<-channel
-	}))
+    slowDownload := 1024 * 10 // 10 KiB/s < 100 KiB/s
+    svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        buffer := make([]byte, slowDownload)
+        for {
+            select {
+            case <-channel:
+                return
+            default:
+                _, err := w.Write(buffer)
+                if err != nil {
+                    return
+                }
+                w.(http.Flusher).Flush()
+                time.Sleep(1 * time.Second)
+            }
+        }
+    }))
 
 	defer svr.CloseClientConnections()
 	defer svr.Close()
@@ -128,12 +140,72 @@ func TestSlowTransfers(t *testing.T) {
 		_, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "")
 		finishedChannel <- true
 	}()
+
+	select {
+	case <-finishedChannel:
+		if err == nil {
+			t.Fatal("Error is nil, download should have failed")
+		}
+	case <-time.After(time.Second * 160):
+		// 120 seconds for warmup, 30 seconds for download
+		t.Fatal("Maximum downloading time reach, download should have failed")
+	}
+
+	// Close the channel to allow the download to complete
+	channel <- true
+
+	// Make sure the errors are correct
+	assert.NotNil(t, err)
+	assert.IsType(t, &SlowTransferError{}, err)
+}
+
+// Test stopped transfer
+func TestStoppedTransfer(t *testing.T) {
+	channel := make(chan bool)
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buffer := make([]byte, 1024 * 100)
+        for {
+            select {
+            case <-channel:
+                return
+            default:
+                _, err := w.Write(buffer)
+                if err != nil {
+                    return
+                }
+                w.(http.Flusher).Flush()
+				time.Sleep(1 * time.Second)
+				buffer = make([]byte, 0)
+            }
+        }
+	}))
+
+	defer svr.CloseClientConnections()
+	defer svr.Close()
+
+	testCache := Cache{
+		AuthEndpoint: svr.URL,
+		Endpoint:     svr.URL,
+		Resource:     "Cache",
+	}
+	transfers := NewTransferDetails(testCache, false)
+	assert.Equal(t, 2, len(transfers))
+	assert.Equal(t, svr.URL, transfers[0].Url.String())
+
+	finishedChannel := make(chan bool)
+	var err error
+
+	go func() {
+		_, err = DownloadHTTP(transfers[0], filepath.Join(t.TempDir(), "test.txt"), "")
+		finishedChannel <- true
+	}()
+
 	select {
 	case <-finishedChannel:
 		if err == nil {
 			t.Fatal("Download should have failed")
 		}
-	case <-time.After(time.Second * 12):
+	case <-time.After(time.Second * 150):
 		t.Fatal("Download should have failed")
 	}
 
@@ -142,9 +214,9 @@ func TestSlowTransfers(t *testing.T) {
 
 	// Make sure the errors are correct
 	assert.NotNil(t, err)
-	assert.IsType(t, &ConnectionSetupError{}, err, err.Error())
-
+	assert.IsType(t, &StoppedTransferError{}, err, err.Error())
 }
+
 
 // Test connection error
 func TestConnectionError(t *testing.T) {


### PR DESCRIPTION
1. Refactor TestSlowTransfer to simulate slow data transfer at 10 KiB/s, below the threshold of 100 KiB/s
2. Introduce StoppedTransfer error when no progress is detected for more than 100 seconds
3. Implement TestStoppedTransfer to simulate a transfer that sends 100 KiB initially, then sleeps for 120 seconds
* Both TestSlowTransfer and Test StoppedTransfer take 150 seconds to pass