### PR TITLE
Update parse_job_ad() and add TestParseJobAd()

### DIFF
--- a/handle_http.go
+++ b/handle_http.go
@@ -26,7 +26,7 @@ import (
 	"github.com/vbauerster/mpb/v7/decor"
 )
 
-var env_prefixes = [...] string {"OSG", "OSDF"}
+var env_prefixes = [...]string{"OSG", "OSDF"}
 
 var p = mpb.New()
 
@@ -217,7 +217,7 @@ func download_http(source string, destination string, payload *payloadStruct, na
 	if namespace.UseTokenOnRead {
 		var err error
 		sourceUrl := url.URL{Path: source}
-		token, err = getToken(&sourceUrl, namespace, false)
+		token, err = getToken(&sourceUrl, namespace, false, tokenName)
 		if err != nil {
 			log.Errorln("Failed to get token though required to read from this namespace:", err)
 			return 0, err
@@ -330,7 +330,7 @@ func startDownloadWorker(source string, destination string, token string, transf
 				errorString := "Failed to download from " + transfer.Url.Hostname() + ":" +
 					transfer.Url.Port() + " "
 				if errors.As(err, &ope) && ope.Op == "proxyconnect" {
-					log.Debugln(ope);
+					log.Debugln(ope)
 					AddrString, _ := os.LookupEnv("http_proxy")
 					if ope.Addr != nil {
 						AddrString = " " + ope.Addr.String()
@@ -554,8 +554,8 @@ Loop:
 		log.Debugln("Got error from HTTP download", err)
 		return 0, err
 	}
-        // Valid responses include 200 and 206.  The latter occurs if the download was resumed after a
-        // prior attempt.
+	// Valid responses include 200 and 206.  The latter occurs if the download was resumed after a
+	// prior attempt.
 	if resp.HTTPResponse.StatusCode != 200 && resp.HTTPResponse.StatusCode != 206 {
 		log.Debugln("Got failure status code:", resp.HTTPResponse.StatusCode)
 		return 0, errors.New("failure status code")

--- a/main.go
+++ b/main.go
@@ -89,6 +89,10 @@ func doWriteBack(source string, destination *url.URL, namespace Namespace) (int6
 
 }
 
+// getToken returns the token to use for the given destination
+//
+// If token_name is not empty, it will be used as the token name.
+// If token_name is empty, the token name will be determined from the destination URL (if possible) using getTokenName
 func getToken(destination *url.URL, namespace Namespace, isWrite bool, token_name string) (string, error) {
 	if token_name == "" {
 		_, token_name = getTokenName(destination)

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func getTokenName(destination *url.URL) (scheme, tokenName string) {
 // Do writeback to stash using SciTokens
 func doWriteBack(source string, destination *url.URL, namespace Namespace) (int64, error) {
 
-	scitoken_contents, err := getToken(destination, namespace, true)
+	scitoken_contents, err := getToken(destination, namespace, true, "")
 	if err != nil {
 		return 0, err
 	}
@@ -89,8 +89,10 @@ func doWriteBack(source string, destination *url.URL, namespace Namespace) (int6
 
 }
 
-func getToken(destination *url.URL, namespace Namespace, isWrite bool) (string, error) {
-	_, token_name := getTokenName(destination)
+func getToken(destination *url.URL, namespace Namespace, isWrite bool, token_name string) (string, error) {
+	if token_name == "" {
+		_, token_name = getTokenName(destination)
+	}
 
 	type tokenJson struct {
 		AccessKey string `json:"access_token"`
@@ -150,6 +152,7 @@ func getToken(destination *url.URL, namespace Namespace, isWrite bool) (string, 
 		if len(token_name) > 0 {
 			token_filename = token_name + ".use"
 		}
+		log.Debugln("Looking for token file:", token_filename)
 		if credsDir, isCondorCredsSet := os.LookupEnv("_CONDOR_CREDS"); token_location == "" && isCondorCredsSet {
 			// Token wasn't specified on the command line or environment, try the default scitoken
 			if _, err := os.Stat(filepath.Join(credsDir, token_filename)); err != nil {

--- a/main.go
+++ b/main.go
@@ -479,7 +479,6 @@ func get_ips(name string) []string {
 func parse_job_ad(payload payloadStruct) { // TODO: needs the payload
 
 	//Parse the .job.ad file for the Owner (username) and ProjectName of the callee.
-
 	condorJobAd, isPresent := os.LookupEnv("_CONDOR_JOB_AD")
 	var filename string
 	if isPresent {
@@ -487,6 +486,7 @@ func parse_job_ad(payload payloadStruct) { // TODO: needs the payload
 	} else if _, err := os.Stat(".job.ad"); err == nil {
 		filename = ".job.ad"
 	} else {
+		log.Warningln(".job.ad doesn't exist", err)
 		return
 	}
 
@@ -494,7 +494,8 @@ func parse_job_ad(payload payloadStruct) { // TODO: needs the payload
 
 	b, err := os.ReadFile(filename)
 	if err != nil {
-		log.Fatal(err)
+		log.Warningln("Can not read .job.ad file", err)
+		// log.Fatal(err)
 	}
 
 	// Get all matches from file

--- a/main.go
+++ b/main.go
@@ -483,6 +483,7 @@ func parse_job_ad(payload payloadStruct) { // TODO: needs the payload
 	var filename string
 	if isPresent {
 		filename = condorJobAd
+
 	} else if _, err := os.Stat(".job.ad"); err == nil {
 		filename = ".job.ad"
 	} else {
@@ -491,11 +492,9 @@ func parse_job_ad(payload payloadStruct) { // TODO: needs the payload
 	}
 
 	// https://stackoverflow.com/questions/28574609/how-to-apply-regexp-to-content-in-file-go
-
 	b, err := os.ReadFile(filename)
 	if err != nil {
 		log.Warningln("Can not read .job.ad file", err)
-		// log.Fatal(err)
 	}
 
 	// Get all matches from file

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,6 @@
 package stashcp
 
 import (
-	"github.com/stretchr/testify/assert"
 	"net"
 	"net/url"
 	"os"
@@ -9,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestGetIps calls main.get_ips with a hostname, checking
@@ -45,7 +46,7 @@ func TestGetToken(t *testing.T) {
 
 	// ENVs to test: BEARER_TOKEN, BEARER_TOKEN_FILE, XDG_RUNTIME_DIR/bt_u<uid>, TOKEN, _CONDOR_CREDS/scitoken.use, .condor_creds/scitokens.use
 	os.Setenv("BEARER_TOKEN", "bearer_token_contents")
-	token, err := getToken(url, namespace, true)
+	token, err := getToken(url, namespace, true, "")
 	assert.NoError(t, err)
 	assert.Equal(t, "bearer_token_contents", token)
 	os.Unsetenv("BEARER_TOKEN")
@@ -58,7 +59,7 @@ func TestGetToken(t *testing.T) {
 	err = os.WriteFile(bearer_token_file, tmpFile, 0644)
 	assert.NoError(t, err)
 	os.Setenv("BEARER_TOKEN_FILE", bearer_token_file)
-	token, err = getToken(url, namespace, true)
+	token, err = getToken(url, namespace, true, "")
 	assert.NoError(t, err)
 	assert.Equal(t, token_contents, token)
 	os.Unsetenv("BEARER_TOKEN_FILE")
@@ -70,7 +71,7 @@ func TestGetToken(t *testing.T) {
 	err = os.WriteFile(bearer_token_file, tmpFile, 0644)
 	assert.NoError(t, err)
 	os.Setenv("XDG_RUNTIME_DIR", tmpDir)
-	token, err = getToken(url, namespace, true)
+	token, err = getToken(url, namespace, true, "")
 	assert.NoError(t, err)
 	assert.Equal(t, token_contents, token)
 	os.Unsetenv("XDG_RUNTIME_DIR")
@@ -82,7 +83,7 @@ func TestGetToken(t *testing.T) {
 	err = os.WriteFile(bearer_token_file, tmpFile, 0644)
 	assert.NoError(t, err)
 	os.Setenv("TOKEN", bearer_token_file)
-	token, err = getToken(url, namespace, true)
+	token, err = getToken(url, namespace, true, "")
 	assert.NoError(t, err)
 	assert.Equal(t, token_contents, token)
 	os.Unsetenv("TOKEN")
@@ -94,7 +95,41 @@ func TestGetToken(t *testing.T) {
 	err = os.WriteFile(bearer_token_file, tmpFile, 0644)
 	assert.NoError(t, err)
 	os.Setenv("_CONDOR_CREDS", tmpDir)
-	token, err = getToken(url, namespace, true)
+	token, err = getToken(url, namespace, true, "")
+	assert.NoError(t, err)
+	assert.Equal(t, token_contents, token)
+	os.Unsetenv("_CONDOR_CREDS")
+
+	// _CONDOR_CREDS/renamed.use
+	token_contents = "bearer_token_file_contents renamed.use"
+	tmpFile = []byte(token_contents)
+	tmpDir = t.TempDir()
+	bearer_token_file = filepath.Join(tmpDir, "renamed.use")
+	err = os.WriteFile(bearer_token_file, tmpFile, 0644)
+	assert.NoError(t, err)
+	os.Setenv("_CONDOR_CREDS", tmpDir)
+	renamedUrl, err := url.Parse("renamed+osdf:///user/ligo/frames")
+	assert.NoError(t, err)
+	renamedNamespace, err := MatchNamespace("/user/ligo/frames")
+	assert.NoError(t, err)
+	token, err = getToken(renamedUrl, renamedNamespace, false, "")
+	assert.NoError(t, err)
+	assert.Equal(t, token_contents, token)
+	os.Unsetenv("_CONDOR_CREDS")
+
+	// _CONDOR_CREDS/renamed.use
+	token_contents = "bearer_token_file_contents renamed.use"
+	tmpFile = []byte(token_contents)
+	tmpDir = t.TempDir()
+	bearer_token_file = filepath.Join(tmpDir, "renamed.use")
+	err = os.WriteFile(bearer_token_file, tmpFile, 0644)
+	assert.NoError(t, err)
+	os.Setenv("_CONDOR_CREDS", tmpDir)
+	renamedUrl, err = url.Parse("/user/ligo/frames")
+	assert.NoError(t, err)
+	renamedNamespace, err = MatchNamespace("/user/ligo/frames")
+	assert.NoError(t, err)
+	token, err = getToken(renamedUrl, renamedNamespace, false, "renamed")
 	assert.NoError(t, err)
 	assert.Equal(t, token_contents, token)
 	os.Unsetenv("_CONDOR_CREDS")
@@ -111,7 +146,7 @@ func TestGetToken(t *testing.T) {
 	assert.NoError(t, err)
 	err = os.Chdir(tmpDir)
 	assert.NoError(t, err)
-	token, err = getToken(url, namespace, true)
+	token, err = getToken(url, namespace, true, "")
 	assert.NoError(t, err)
 	assert.Equal(t, token_contents, token)
 	err = os.Chdir(currentDir)

--- a/main_test.go
+++ b/main_test.go
@@ -203,20 +203,12 @@ func FuzzGetTokenName(f *testing.F) {
 
 func TestParseJobAd(t *testing.T) {
 	// Job ad file does not exist
-	err := os.WriteFile(".job.ad", []byte("Owner = \"john\"\nProjectName = \"test-project\""), 0644)
-	if err != nil {
-		t.Fatal("Failed to create job ad file")
-	}
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, ".job.ad")
+	os.Setenv("_CONDOR_JOB_AD", path)
+
 	payload := payloadStruct{}
-	os.Remove(".job.ad")
 	parse_job_ad(payload)
 
-	// Job ad file exists but cannot be read
-	payload = payloadStruct{}
-	err = os.WriteFile(".job.ad", []byte("Owner = \"john\"\nProjectName = \"test-project\""), 0000)
-	if err != nil {
-		t.Fatal("Failed to create unreadable job ad file")
-	}
-	parse_job_ad(payload)
-	os.Remove(".job.ad")
 }
+

--- a/main_test.go
+++ b/main_test.go
@@ -200,3 +200,23 @@ func FuzzGetTokenName(f *testing.F) {
 		assert.Equal(t, strings.ToLower(orig), tokenName, "URL: "+urlString+"URL String: "+url.String()+" Scheme: "+url.Scheme)
 	})
 }
+
+func TestParseJobAd(t *testing.T) {
+	// Job ad file does not exist
+	err := os.WriteFile(".job.ad", []byte("Owner = \"john\"\nProjectName = \"test-project\""), 0644)
+	if err != nil {
+		t.Fatal("Failed to create job ad file")
+	}
+	payload := payloadStruct{}
+	os.Remove(".job.ad")
+	parse_job_ad(payload)
+
+	// Job ad file exists but cannot be read
+	payload = payloadStruct{}
+	err = os.WriteFile(".job.ad", []byte("Owner = \"john\"\nProjectName = \"test-project\""), 0000)
+	if err != nil {
+		t.Fatal("Failed to create unreadable job ad file")
+	}
+	parse_job_ad(payload)
+	os.Remove(".job.ad")
+}


### PR DESCRIPTION
1. The parse_job_ad function now prints a warning message instead of exiting if the job ad file cannot be found or read.
2. A new TestParseJobAd function was added to test the parse_job_ad function in cases where the .job.ad file does not exist or cannot be read.