### PR TITLE
Update parse_job_ad() and add TestParseJobAd()

### DIFF
--- a/main.go
+++ b/main.go
@@ -494,7 +494,7 @@ func parse_job_ad(payload payloadStruct) { // TODO: needs the payload
 
 	b, err := os.ReadFile(filename)
 	if err != nil {
-		log.Fatal(err)
+		log.Warningln("Can not read .job.ad file", err)
 	}
 
 	// Get all matches from file

--- a/main_test.go
+++ b/main_test.go
@@ -201,7 +201,7 @@ func FuzzGetTokenName(f *testing.F) {
 	})
 }
 
-func TestParseJobAd(t *testing.T) {
+func TestParseNoJobAd(t *testing.T) {
 	// Job ad file does not exist
 	tempDir := t.TempDir()
 	path := filepath.Join(tempDir, ".job.ad")

--- a/main_test.go
+++ b/main_test.go
@@ -200,3 +200,13 @@ func FuzzGetTokenName(f *testing.F) {
 		assert.Equal(t, strings.ToLower(orig), tokenName, "URL: "+urlString+"URL String: "+url.String()+" Scheme: "+url.Scheme)
 	})
 }
+
+func TestParseJobAd(t *testing.T) {
+	// Job ad file does not exist
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, ".job.ad")
+	os.Setenv("_CONDOR_JOB_AD", path)
+
+	payload := payloadStruct{}
+	parse_job_ad(payload)
+}


### PR DESCRIPTION
1. The parse_job_ad function now prints a warning message instead of exiting if the job ad file cannot be found or read.
2. A new TestParseJobAd function was added to test the parse_job_ad function in cases where the .job.ad file does not exist.