### PR TITLE
Implementing and Testing Server-Side HTTP Trailer Mechanism with Status Parsing

### DIFF
--- a/handle_http.go
+++ b/handle_http.go
@@ -379,17 +379,17 @@ func startDownloadWorker(source string, destination string, token string, transf
 }
 
 func parseTransferStatus(status string) (int, string) {
-    parts := strings.SplitN(status, ": ", 2)
-    if len(parts) != 2 {
-        return 0, ""
-    }
+	parts := strings.SplitN(status, ": ", 2)
+	if len(parts) != 2 {
+		return 0, ""
+	}
 
-    statusCode, err := strconv.Atoi(strings.TrimSpace(parts[0]))
-    if err != nil {
-        return 0, ""
-    }
+	statusCode, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, ""
+	}
 
-    return statusCode, strings.TrimSpace(parts[1])
+	return statusCode, strings.TrimSpace(parts[1])
 }
 
 // DownloadHTTP - Perform the actual download of the file
@@ -422,8 +422,8 @@ func DownloadHTTP(transfer TransferDetails, dest string, token string) (int64, e
 		req.HTTPRequest.Header.Set("Authorization", "Bearer "+token)
 	}
 	// Set the headers
-    req.HTTPRequest.Header.Set("X-Transfer-Status", "true")
-    req.HTTPRequest.Header.Set("TE", "trailers")
+	req.HTTPRequest.Header.Set("X-Transfer-Status", "true")
+	req.HTTPRequest.Header.Set("TE", "trailers")
 	req.WithContext(ctx)
 
 	// Test the transfer speed every 5 seconds
@@ -610,7 +610,7 @@ Loop:
 				return 0, errors.New("transfer error: " + statusText)
 			}
 		}
-    }
+	}
 	// Valid responses include 200 and 206.  The latter occurs if the download was resumed after a
 	// prior attempt.
 	if resp.HTTPResponse.StatusCode != 200 && resp.HTTPResponse.StatusCode != 206 {

--- a/handle_http.go
+++ b/handle_http.go
@@ -378,6 +378,20 @@ func startDownloadWorker(source string, destination string, token string, transf
 	}
 }
 
+func parseTransferStatus(status string) (int, string) {
+    parts := strings.SplitN(status, ": ", 2)
+    if len(parts) != 2 {
+        return 0, ""
+    }
+
+    statusCode, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+    if err != nil {
+        return 0, ""
+    }
+
+    return statusCode, strings.TrimSpace(parts[1])
+}
+
 // DownloadHTTP - Perform the actual download of the file
 func DownloadHTTP(transfer TransferDetails, dest string, token string) (int64, error) {
 
@@ -407,6 +421,9 @@ func DownloadHTTP(transfer TransferDetails, dest string, token string) (int64, e
 	if token != "" {
 		req.HTTPRequest.Header.Set("Authorization", "Bearer "+token)
 	}
+	// Set the headers
+    req.HTTPRequest.Header.Set("X-Transfer-Status", "true")
+    req.HTTPRequest.Header.Set("TE", "trailers")
 	req.WithContext(ctx)
 
 	// Test the transfer speed every 5 seconds
@@ -583,7 +600,17 @@ Loop:
 		}
 		log.Debugln("Got error from HTTP download", err)
 		return 0, err
-	}
+	} else {
+		// Check the trailers for any error information
+		trailer := resp.HTTPResponse.Trailer
+		if errorStatus := trailer.Get("X-Transfer-Status"); errorStatus != "" {
+			statusCode, statusText := parseTransferStatus(errorStatus)
+			if statusCode != 200 {
+				log.Debugln("Got error from file transfer")
+				return 0, errors.New("transfer error: " + statusText)
+			}
+		}
+    }
 	// Valid responses include 200 and 206.  The latter occurs if the download was resumed after a
 	// prior attempt.
 	if resp.HTTPResponse.StatusCode != 200 && resp.HTTPResponse.StatusCode != 206 {


### PR DESCRIPTION
This commit implements the server-side HTTP trailer mechanism, introduces a corresponding test function, and adds a utility to parse the transfer status from the server's response.

In the server-side implementation, we allow a user to set specific headers (X-Transfer-Status and TE) in the request (XRootD [#2009](https://github.com/xrootd/xrootd/pull/2009)), and then employ chunked encoding in the response. The final chunk returned indicates if an error has occurred.

In order to match this update, we now set these headers in the HTTPRequest. After the response ends, we check for the presence of X-Transfer-Status and the status code. A utility function parseTransferStatus() has been added to extract the status code and status text from the 'X-Transfer-Status' trailer. This function splits the status string into the code and message. If the status code is anything other than 200, an error message is dispatched to the user.

We've also added a new test function 'TestTrailerError' that simulates an HTTP server returning an error trailer, writes some data, and then invokes the 'DownloadHTTP' function. It then checks if the correct error is returned, as expected.

With these changes, we hope to enhance error reporting when there is an IO error in the middle of the response.