### PR TITLE
Minor tweak on error reporting.

### DIFF
--- a/cmd/stashcp/main.go
+++ b/cmd/stashcp/main.go
@@ -241,7 +241,11 @@ func main() {
 	// Exit with failure
 	if result != nil {
 		// Print the list of errors
-		log.Errorln("Failure downloading " + lastSrc + ": " + stashcp.GetErrors())
+		errMsg := stashcp.GetErrors()
+		if errMsg == "" {
+			errMsg = result.Error()
+		}
+		log.Errorln("Failure downloading " + lastSrc + ": " + errMsg)
 		if stashcp.ErrorsRetryable() {
 			log.Errorln("Errors are retryable")
 			os.Exit(11)

--- a/main.go
+++ b/main.go
@@ -335,6 +335,7 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 
 	ns, err := MatchNamespace(source_url.Path)
 	if err != nil {
+		AddError(err)
 		return 0, err
 	}
 


### PR DESCRIPTION
- If MatchNamespaces fails, report it as a process-wide error.
- If no process-wide errors are reported, use the last returned error as the error message.