### PR TITLE
Correct namespace lookup for downloading osdf://-style URLs

### DIFF
--- a/main.go
+++ b/main.go
@@ -284,7 +284,7 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 
 	// If there is a host specified, prepend it to the path
 	if source_url.Host != "" {
-		source_url.Path = path.Join(source_url.Host, source_url.Path)
+		source_url.Path = "/" + path.Join(source_url.Host, source_url.Path)
 	}
 
 	if dest_url.Host != "" {


### PR DESCRIPTION
When `stashcp` is run with an `osdf://` source without a third slash (i.e., `osdf://foo/bar` instead of `osdf:///foo/bar`), then the path fed into the namespace lookup lacked a leading `/` (i.e., `foo/bar`) resulting in a failed lookup.

It otherwise appeared that the lookup worked because it fell back to the default set of public caches (which works in some cases).