### PR TITLE
Fail for unknown namespace.

### DIFF
--- a/namespaces.go
+++ b/namespaces.go
@@ -174,5 +174,9 @@ func MatchNamespace(path string) (Namespace, error) {
 			best = namespace
 		}
 	}
+	if best.Path == "" {
+		return Namespace{}, errors.New("OSDF namespace not known for path " + path)
+	}
+	log.Debugln("Selected namespace:", best)
 	return best, nil
 }

--- a/namespaces_test.go
+++ b/namespaces_test.go
@@ -76,7 +76,7 @@ func TestMatchNamespace(t *testing.T) {
 
 	// Check for empty
 	ns, err = MatchNamespace("/does/not/exist.txt")
-	assert.NoError(t, err, "Failed to parse namespace")
+	assert.Error(t, err, "Failed to parse namespace")
 	assert.Equal(t, "", ns.Path)
 	assert.Equal(t, Namespace{}.UseTokenOnRead, ns.UseTokenOnRead)
 


### PR DESCRIPTION
If a prefix is not in a registered namespace, instead of effectively falling back to a default set of caches, return a failure.

This is meant to provide reasonable error messages when there are typos in the URL instead of making it look like there's an issue with the caches.

Here's an example output from `stashcp`:

```
stashcp osdf://typo/staging/bbockelm/foo /dev/null
ERROR[2023-06-03T10:58:53-05:00] Failure downloading osdf://typo/staging/bbockelm/foo: Attempt #1: OSDF namespace not known for path /typo/staging/bbockelm/foo (100ms since start)
```