### PR TITLE
Improvements to the error messages on upload failures.

### DIFF
--- a/cmd/stashcp/main.go
+++ b/cmd/stashcp/main.go
@@ -245,7 +245,7 @@ func main() {
 		if errMsg == "" {
 			errMsg = result.Error()
 		}
-		log.Errorln("Failure downloading " + lastSrc + ": " + errMsg)
+		log.Errorln("Failure transferring " + lastSrc + ": " + errMsg)
 		if stashcp.ErrorsRetryable() {
 			log.Errorln("Errors are retryable")
 			os.Exit(11)

--- a/errorAccum.go
+++ b/errorAccum.go
@@ -91,6 +91,18 @@ func IsRetryable(err error) bool {
 		}
 		return true
 	}
+	var hep *HttpErrResp
+	if errors.As(err, &hep) {
+		switch int(hep.Code) {
+		case http.StatusInternalServerError:
+		case http.StatusBadGateway:
+		case http.StatusServiceUnavailable:
+		case http.StatusGatewayTimeout:
+			return true
+		default:
+			return false
+		}
+	}
 	return false
 }
 

--- a/handle_http.go
+++ b/handle_http.go
@@ -39,6 +39,16 @@ func (e *StoppedTransferError) Error() string {
 }
 
 
+type HttpErrResp struct {
+	Code int
+	Err string
+}
+
+func (e *HttpErrResp) Error() string {
+	return e.Err
+}
+
+
 // SlowTransferError is an error that is returned when a transfer takes longer than the configured timeout
 type SlowTransferError struct {
 	BytesTransferred int64
@@ -641,7 +651,8 @@ Loop:
 	// prior attempt.
 	if resp.HTTPResponse.StatusCode != 200 && resp.HTTPResponse.StatusCode != 206 {
 		log.Debugln("Got failure status code:", resp.HTTPResponse.StatusCode)
-		return 0, errors.New("failure status code")
+		return 0, &HttpErrResp{resp.HTTPResponse.StatusCode, fmt.Sprintf("Request failed (HTTP status %d): %s",
+		    resp.HTTPResponse.StatusCode, resp.Err().Error())}
 	}
 	log.Debugln("HTTP Transfer was successful")
 	return resp.BytesComplete(), nil
@@ -760,7 +771,8 @@ Loop:
 		case response := <-responseChan:
 			if response.StatusCode != 200 {
 				log.Errorln("Got failure status code:", response.StatusCode)
-				lastError = errors.New("failure status code")
+				lastError = &HttpErrResp{response.StatusCode, fmt.Sprintf("Request failed (HTTP status %d)",
+				    response.StatusCode)}
 				break Loop
 			}
 			break Loop

--- a/main.go
+++ b/main.go
@@ -334,8 +334,12 @@ func DoStashCPSingle(sourceFile string, destination string, methods []string, re
 		ns, err := MatchNamespace(dest_url.Path)
 		if err != nil {
 			log.Errorln("Failed to get namespace information:", err)
+			AddError(err)
+			return 0, err
 		}
-		return doWriteBack(source_url.Path, dest_url, ns)
+		_, err = doWriteBack(source_url.Path, dest_url, ns)
+		AddError(err)
+		return 0, err
 	}
 
 	if dest_url.Scheme == "file" {


### PR DESCRIPTION
- Capture the HTTP status code on failure (esp. for uploads) and add it to the error accumulator.
- Use the error accumulator mechanism for uploads.
- Ensure that fatal upload failures aren't labelled retryable.
- When generating upload error messages, don't use the word "downloading"