### PR TITLE
Remove content length from put to enable chunked

### DIFF
--- a/handle_http.go
+++ b/handle_http.go
@@ -728,7 +728,6 @@ func UploadFile(src string, dest *url.URL, token string, namespace namespaces.Na
 		log.Errorln("Error creating request:", err)
 		return 0, err
 	}
-	request.ContentLength = fileInfo.Size()
 	// Set the authorization header
 	request.Header.Set("Authorization", "Bearer "+token)
 	var lastKnownWritten int64


### PR DESCRIPTION
Removing the content length from a put changes the upload style from full file upload to a chunked encoded upload.  A full file upload causes go to read in the entire file in memory while uploading, chunked does not.

**NOTE** chunked uploads only work after xrootd has merged and put into production https://github.com/xrootd/xrootd/pull/2102 